### PR TITLE
Add "id" attributes from Racket; other markup changes.

### DIFF
--- a/srfi-29.html
+++ b/srfi-29.html
@@ -114,7 +114,7 @@
     program may also retrieve the elements of the current locale
     using the no-argument procedures:</p>
 
-    <p><b><code>current-language</code></b> <code>-&gt;
+    <p><b><code id="current-language">current-language</code></b> <code>-&gt;
     <i>symbol</i></code><br>
      <code><b>current-language</b> <i>symbol</i> -&gt;
     undefined</code><br>
@@ -129,7 +129,7 @@
       &nbsp;
     </blockquote>
 
-    <p><b><code>current-country</code></b> <code>-&gt;
+    <p><b><code id="current-country">current-country</code></b> <code>-&gt;
     <i>symbol</i></code><br>
      <code><b>current-country</b> <i>symbol</i> -&gt;
     undefined</code><br>
@@ -143,7 +143,7 @@
       distinction is not possible). &nbsp;&nbsp;
     </blockquote>
 
-    <p><b><code>current-locale-details</code></b> <code>-&gt; <i>list of
+    <p><b><code id="current-locale-details">current-locale-details</code></b> <code>-&gt; <i>list of
     symbol</i></code>s<br>
      <code><b>current-locale-details</b> <i>list-of-symbols</i> -&gt;
     undefined</code><br>
@@ -203,7 +203,7 @@
     outside the Scheme system.<br>
 
 
-    <p><b><code>declare-bundle!</code></b> <code><i>bundle-specifier
+    <p><b><code id="declare-bundle!">declare-bundle!</code></b> <code><i>bundle-specifier
     association-list</i> -&gt; undefined<br>
     </code></p>
 
@@ -216,7 +216,7 @@
       given name, it is overwritten with the newly declared
       bundle.<br>
     </blockquote>
-    <code><b>store-bundle</b> <i>bundle-specifier</i> -&gt;
+    <code id="store-bundle"><b>store-bundle</b> <i>bundle-specifier</i> -&gt;
     boolean</code><br>
 
 
@@ -228,7 +228,7 @@
       system restarts. &nbsp;If successful, a non-false value is
       returned. &nbsp;If unsuccessful, <code>#f</code> is returned.<br>
     </blockquote>
-    <code><b>load-bundle!</b> <i>bundle-specifier</i> -&gt;
+    <code id="load-bundle!"><b>load-bundle!</b> <i>bundle-specifier</i> -&gt;
     boolean</code><br>
 
 
@@ -253,7 +253,7 @@
 
     <h3>Retrieving Localized Message Templates</h3>
 
-    <p><b><code>localized-template</code></b> <i><code>package-name
+    <p><b><code id="localized-template">localized-template</code></b> <i><code>package-name
     message-template-name</code></i> <code>-&gt; <i>string or #f<br>
     </i></code></p>
 

--- a/srfi-29.html
+++ b/srfi-29.html
@@ -1,24 +1,17 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
-    <meta name="generator" content="HTML Tidy, see www.w3.org">
+    <meta charset="utf-8">
     <title>SRFI 29: Localization</title>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link rel="stylesheet" href="/srfi.css" type="text/css" />
-    <meta name="author" content="Scott G. Miller">
-    <meta name="description" content="Localization">
-  </head>
+    <link href="/favicon.png" rel="icon" sizes="192x192" type="image/png">
+    <link rel="stylesheet" href="https://srfi.schemers.org/srfi.css" type="text/css">
+    <meta name="viewport" content="width=device-width, initial-scale=1"></head>
   <body>
-    <h1>Title</h1>
+    <h1><a href="https://srfi.schemers.org/"><img class="srfi-logo" src="https://srfi.schemers.org/srfi-logo.svg" alt="SRFI surfboard logo" /></a>29: Localization</h1>
 
-    Localization
+<p>by Scott G. Miller</p>
 
-    <h1>Author</h1>
-
-    Scott G. Miller
-
-    <h1>Status</h1>
+<h2 id="status">Status</h2>
 
     <p>This SRFI is currently in <em>final</em> status.  Here is <a href="https://srfi.schemers.org/srfi-process.html">an explanation</a> of each status that a SRFI can hold.  To provide input on this SRFI, please send email to <code><a href="mailto:srfi+minus+29+at+srfi+dotschemers+dot+org">srfi-29@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.  To subscribe to the list, follow <a href="https://srfi.schemers.org/srfi-list-subscribe.html">these instructions</a>.  You can access previous messages via the mailing list <a href="https://srfi-email.schemers.org/srfi-29">archive</a>.</p>
 <ul>
@@ -26,17 +19,17 @@
       <li>Final: 2002-06-19
     </ul>
 
-    <h1>Abstract</h1>
+    <h2 id="abstract">Abstract</h2>
 
-    This document specifies an interface to retrieving and
+    <p>This document specifies an interface to retrieving and
     displaying locale sensitive messages. A Scheme program can
     register one or more translations of templated messages, and
     then write Scheme code that can transparently retrieve the
     appropriate message for the locale under which the Scheme
-    system is running. <br>
+    system is running.</p>
 
 
-    <h1>Rationale</h1>
+    <h2 id="rationale">Rationale</h2>
 
     <p>As any programmer that has ever had to deal with making his
     or her code readable in more than one locale, the process of
@@ -65,14 +58,14 @@
     number and date formatting, etc. Such functionality is the
     scope of a future SRFI that may extend this one.</p>
 
-    <h1>Dependencies</h1>
+    <h2 id="dependencies">Dependencies</h2>
 
-    A SRFI-29 conformant implementation must also implement
+    <p>A SRFI-29 conformant implementation must also implement
     SRFI-28, Basic Format Strings. Message templates are strings
     that must be processed by the <code>format</code> function
-    specified in that SRFI.
+    specified in that SRFI.</p>
 
-    <h1>Specification</h1>
+    <h2 id="specification">Specification</h2>
 
     <h3>Message Bundles</h3>
 
@@ -190,17 +183,17 @@
       optional value absolutely, rather than the next unconsumed
       value. The referenced value is <i>not</i> consumed.
     </blockquote>
-    This extension allows optional values to be positionally
+    <p>This extension allows optional values to be positionally
     referenced, so that message templates can be constructed that
-    can produce the proper word ordering for a language.
+    can produce the proper word ordering for a language.</p>
 
     <h3>Preparing Bundles</h3>
-    Before a bundle may be used by the Scheme system to retrieve
+    <p>Before a bundle may be used by the Scheme system to retrieve
     localized template messages, they must be made available to the
     Scheme system. &nbsp;This SRFI specifies a way to portably
     define the bundles, as well as store them in and retrieve them
     from an unspecified system which may be provided by resources
-    outside the Scheme system.<br>
+    outside the Scheme system.</p>
 
 
     <p><b><code id="declare-bundle!">declare-bundle!</code></b> <code><i>bundle-specifier
@@ -241,14 +234,14 @@
       successfully, the function returns <code>#f</code>, and the
       Scheme system's bundle registry remains unaffected.<br>
     </blockquote>
-    A compliant Scheme system may choose not to provide any
+    <p>A compliant Scheme system may choose not to provide any
     external mechanism to store localized bundles. &nbsp;If it does
     not, it must still provide implementations for
     <code>store-bundle</code> and <code>load-bundle!</code>. In such a
     case, both functions must return <code>#f</code> regardless of the
     arguments given. Users of this SRFI should recognize that the
     inability to load or store a localized bundle in an external
-    repository is <i>not</i> a fatal error.<br>
+    repository is <i>not</i> a fatal error.</p>
 
 
     <h3>Retrieving Localized Message Templates</h3>
@@ -264,16 +257,16 @@
       returned.<br>
       <br>
     </blockquote>
-    After retrieving a template, the calling program can use
+    <p>After retrieving a template, the calling program can use
     <code>format</code> to produce a string that can be displayed to
-    the user.<br>
+    the user.</p>
 
 
-    <h2>Examples</h2>
-    The below example makes use of SRFI-29 to display simple,
+    <h3>Examples</h3>
+   <p>The below example makes use of SRFI-29 to display simple,
     localized messages. &nbsp;It also defines its bundles in such a
     way that the Scheme system may store and retrieve the bundles
-    from a more efficient system catalog, if available.<br>
+    from a more efficient system catalog, if available.</p>
 
 <pre>
 (let ((translations
@@ -311,7 +304,7 @@
 ;; Au revoir, Fred.
 </pre>
 
-    <h1>Implementation</h1>
+    <h2 id="implementation">Implementation</h2>
 
     <p>The implementation requires that the Scheme system provide a
     definition for <code>current-language</code> and
@@ -471,8 +464,8 @@
 
 </pre>
 
-    <h1 id="copyright">Copyright</h1>
-    &copy; 2002 Scott G. Miller.
+    <h2 id="copyright">Copyright</h2>
+    <p>&copy; 2002 Scott G. Miller.</p>
 
     <p>
       Permission is hereby granted, free of charge, to any person

--- a/srfi-29.html
+++ b/srfi-29.html
@@ -10,15 +10,15 @@
     <meta name="description" content="Localization">
   </head>
   <body>
-    <H1>Title</H1>
+    <h1>Title</h1>
 
     Localization
 
-    <H1>Author</H1>
+    <h1>Author</h1>
 
     Scott G. Miller
 
-    <H1>Status</H1>
+    <h1>Status</h1>
 
     <p>This SRFI is currently in <em>final</em> status.  Here is <a href="https://srfi.schemers.org/srfi-process.html">an explanation</a> of each status that a SRFI can hold.  To provide input on this SRFI, please send email to <code><a href="mailto:srfi+minus+29+at+srfi+dotschemers+dot+org">srfi-29@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.  To subscribe to the list, follow <a href="https://srfi.schemers.org/srfi-list-subscribe.html">these instructions</a>.  You can access previous messages via the mailing list <a href="https://srfi-email.schemers.org/srfi-29">archive</a>.</p>
 <ul>
@@ -26,7 +26,7 @@
       <li>Final: 2002-06-19
     </ul>
 
-    <H1>Abstract</H1>
+    <h1>Abstract</h1>
 
     This document specifies an interface to retrieving and
     displaying locale sensitive messages. A Scheme program can
@@ -36,7 +36,7 @@
     system is running. <br>
 
 
-    <H1>Rationale</H1>
+    <h1>Rationale</h1>
 
     <p>As any programmer that has ever had to deal with making his
     or her code readable in more than one locale, the process of
@@ -65,14 +65,14 @@
     number and date formatting, etc. Such functionality is the
     scope of a future SRFI that may extend this one.</p>
 
-    <H1>Dependencies</H1>
+    <h1>Dependencies</h1>
 
     A SRFI-29 conformant implementation must also implement
     SRFI-28, Basic Format Strings. Message templates are strings
     that must be processed by the <code>format</code> function
     specified in that SRFI.
 
-    <H1>Specification</H1>
+    <h1>Specification</h1>
 
     <h3>Message Bundles</h3>
 
@@ -311,7 +311,7 @@
 ;; Au revoir, Fred.
 </pre>
 
-    <H1>Implementation</H1>
+    <h1>Implementation</h1>
 
     <p>The implementation requires that the Scheme system provide a
     definition for <code>current-language</code> and
@@ -471,7 +471,7 @@
 
 </pre>
 
-    <H1 id="copyright">Copyright</H1>
+    <h1 id="copyright">Copyright</h1>
     &copy; 2002 Scott G. Miller.
 
     <p>

--- a/srfi-29.html
+++ b/srfi-29.html
@@ -1,274 +1,286 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>SRFI 29: Localization</title>
-    <link href="/favicon.png" rel="icon" sizes="192x192" type="image/png">
-    <link rel="stylesheet" href="https://srfi.schemers.org/srfi.css" type="text/css">
-    <meta name="viewport" content="width=device-width, initial-scale=1"></head>
-  <body>
-    <h1><a href="https://srfi.schemers.org/"><img class="srfi-logo" src="https://srfi.schemers.org/srfi-logo.svg" alt="SRFI surfboard logo" /></a>29: Localization</h1>
+<head>
+  <meta name="generator" content=
+  "HTML Tidy for HTML5 for Linux version 5.8.0">
+  <meta charset="utf-8">
+  <title>SRFI 29: Localization</title>
+  <link href="/favicon.png" rel="icon" sizes="192x192" type=
+  "image/png">
+  <link rel="stylesheet" href="https://srfi.schemers.org/srfi.css"
+  type="text/css">
+  <meta name="viewport" content=
+  "width=device-width, initial-scale=1">
+</head>
+<body>
+  <h1><a href="https://srfi.schemers.org/"><img class="srfi-logo"
+  src="https://srfi.schemers.org/srfi-logo.svg" alt=
+  "SRFI surfboard logo"></a>29: Localization</h1>
 
-<p>by Scott G. Miller</p>
+  <p>by Scott G. Miller</p>
 
-<h2 id="status">Status</h2>
+  <h2 id="status">Status</h2>
 
-    <p>This SRFI is currently in <em>final</em> status.  Here is <a href="https://srfi.schemers.org/srfi-process.html">an explanation</a> of each status that a SRFI can hold.  To provide input on this SRFI, please send email to <code><a href="mailto:srfi+minus+29+at+srfi+dotschemers+dot+org">srfi-29@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.  To subscribe to the list, follow <a href="https://srfi.schemers.org/srfi-list-subscribe.html">these instructions</a>.  You can access previous messages via the mailing list <a href="https://srfi-email.schemers.org/srfi-29">archive</a>.</p>
-<ul>
-      <li>Draft: 2002-03-26--2002-06-19</li>
-      <li>Final: 2002-06-19
-    </ul>
+  <p>This SRFI is currently in <em>final</em> status. Here is
+  <a href="https://srfi.schemers.org/srfi-process.html">an
+  explanation</a> of each status that a SRFI can hold. To provide
+  input on this SRFI, please send email to <code><a href=
+  "mailto:srfi+minus+29+at+srfi+dotschemers+dot+org">srfi-29@<span class="antispam">nospam</span>srfi.schemers.org</a></code>.
+  To subscribe to the list, follow <a href=
+  "https://srfi.schemers.org/srfi-list-subscribe.html">these
+  instructions</a>. You can access previous messages via the
+  mailing list <a href=
+  "https://srfi-email.schemers.org/srfi-29">archive</a>.</p>
 
-    <h2 id="abstract">Abstract</h2>
+  <ul>
+    <li>Draft: 2002-03-26--2002-06-19</li>
 
-    <p>This document specifies an interface to retrieving and
-    displaying locale sensitive messages. A Scheme program can
-    register one or more translations of templated messages, and
-    then write Scheme code that can transparently retrieve the
-    appropriate message for the locale under which the Scheme
-    system is running.</p>
+    <li>Final: 2002-06-19</li>
+  </ul>
 
+  <h2 id="abstract">Abstract</h2>
 
-    <h2 id="rationale">Rationale</h2>
+  <p>This document specifies an interface to retrieving and
+  displaying locale sensitive messages. A Scheme program can
+  register one or more translations of templated messages, and then
+  write Scheme code that can transparently retrieve the appropriate
+  message for the locale under which the Scheme system is
+  running.</p>
 
-    <p>As any programmer that has ever had to deal with making his
-    or her code readable in more than one locale, the process of
-    sufficiently abstracting program messages from their
-    presentation to the user is non-trivial without help from the
-    programming language. Most modern programming language
-    libraries do provide some mechanism for performing this
-    separation.</p>
+  <h2 id="rationale">Rationale</h2>
 
-    <p>A portable API that allows a piece of code to run without
-    modification in different countries and under different
-    languages is a must for any non-trivial software project.
-    &nbsp;The interface should separate the logic of a program from
-    the myriad of translations that may be necessary.</p>
+  <p>As any programmer that has ever had to deal with making his or
+  her code readable in more than one locale, the process of
+  sufficiently abstracting program messages from their presentation
+  to the user is non-trivial without help from the programming
+  language. Most modern programming language libraries do provide
+  some mechanism for performing this separation.</p>
 
-    <p>The interface described in this document provides such
-    functionality. The underlying implementation is also allowed to
-    use whatever datastructures it likes to provide access to the
-    translations in the most efficient manner possible. &nbsp;In
-    addition, the implementation is provided with standardized
-    functions that programs will use for accessing an external,
-    unspecified repository of translations.</p>
+  <p>A portable API that allows a piece of code to run without
+  modification in different countries and under different languages
+  is a must for any non-trivial software project. &nbsp;The
+  interface should separate the logic of a program from the myriad
+  of translations that may be necessary.</p>
 
-    <p>This interface <i>does not</i> cover all aspects of
-    localization, including support for non-latin characters,
-    number and date formatting, etc. Such functionality is the
-    scope of a future SRFI that may extend this one.</p>
+  <p>The interface described in this document provides such
+  functionality. The underlying implementation is also allowed to
+  use whatever datastructures it likes to provide access to the
+  translations in the most efficient manner possible. &nbsp;In
+  addition, the implementation is provided with standardized
+  functions that programs will use for accessing an external,
+  unspecified repository of translations.</p>
 
-    <h2 id="dependencies">Dependencies</h2>
+  <p>This interface <i>does not</i> cover all aspects of
+  localization, including support for non-latin characters, number
+  and date formatting, etc. Such functionality is the scope of a
+  future SRFI that may extend this one.</p>
 
-    <p>A SRFI-29 conformant implementation must also implement
-    SRFI-28, Basic Format Strings. Message templates are strings
-    that must be processed by the <code>format</code> function
-    specified in that SRFI.</p>
+  <h2 id="dependencies">Dependencies</h2>
 
-    <h2 id="specification">Specification</h2>
+  <p>A SRFI-29 conformant implementation must also implement
+  SRFI-28, Basic Format Strings. Message templates are strings that
+  must be processed by the <code>format</code> function specified
+  in that SRFI.</p>
 
-    <h3>Message Bundles</h3>
+  <h2 id="specification">Specification</h2>
 
-    <p>A Message Bundle is a set of message templates and their
-    identifying keys. Each bundle contains one or more such
-    key/value pairs. The bundle itself is associated with a
-    <i>bundle specifier</i> which uniquely identifies the
-    bundle.</p>
+  <h3>Message Bundles</h3>
 
-    <h3>Bundle Specifiers</h3>
+  <p>A Message Bundle is a set of message templates and their
+  identifying keys. Each bundle contains one or more such key/value
+  pairs. The bundle itself is associated with a <i>bundle
+  specifier</i> which uniquely identifies the bundle.</p>
 
-    <p>A Bundle Specifier is a Scheme list that describes, in order
-    of importance, the package and locale of a message bundle.
-    &nbsp;In most cases, a locale specifier will have between one
-    and three elements. The first element is a symbol denoting the
-    package for which this bundle applies. The second and third
-    elements denote a <i>locale</i>. The second element (first
-    element of the locale) if present, is the two letter, ISO 639-1
-    language code for the bundle. The third element, if present, is
-    a two letter ISO 3166-1 country code. &nbsp;In some cases, a
-    fourth element may be present, specifying the encoding used for
-    the bundle. &nbsp;All bundle specifier elements are Scheme
-    symbols.</p>
+  <h3>Bundle Specifiers</h3>
 
-    <p>If only one translation is provided, it should be designated
-    only by a package name, for example <code>(mathlib)</code>. This
-    translation is called the <i>default</i> translation.</p>
+  <p>A Bundle Specifier is a Scheme list that describes, in order
+  of importance, the package and locale of a message bundle.
+  &nbsp;In most cases, a locale specifier will have between one and
+  three elements. The first element is a symbol denoting the
+  package for which this bundle applies. The second and third
+  elements denote a <i>locale</i>. The second element (first
+  element of the locale) if present, is the two letter, ISO 639-1
+  language code for the bundle. The third element, if present, is a
+  two letter ISO 3166-1 country code. &nbsp;In some cases, a fourth
+  element may be present, specifying the encoding used for the
+  bundle. &nbsp;All bundle specifier elements are Scheme
+  symbols.</p>
 
-    <h3>Bundle Searching</h3>
+  <p>If only one translation is provided, it should be designated
+  only by a package name, for example <code>(mathlib)</code>. This
+  translation is called the <i>default</i> translation.</p>
 
-    <p>When a message template is retrieved from a bundle, the
-    Scheme implementation will provide the locale under which the
-    system is currently running. When the template is retrieved,
-    the package name will be specified. The Scheme system should
-    construct a Bundle Specifier from the provided package name and
-    the active locale. For example, when retrieving a message
-    template for French Canadian, in the <code>mathlib</code> package,
-    the bundle specifier '<code>(mathlib fr ca)</code>' is used. A
-    program may also retrieve the elements of the current locale
-    using the no-argument procedures:</p>
+  <h3>Bundle Searching</h3>
 
-    <p><b><code id="current-language">current-language</code></b> <code>-&gt;
-    <i>symbol</i></code><br>
-     <code><b>current-language</b> <i>symbol</i> -&gt;
-    undefined</code><br>
-    </p>
+  <p>When a message template is retrieved from a bundle, the Scheme
+  implementation will provide the locale under which the system is
+  currently running. When the template is retrieved, the package
+  name will be specified. The Scheme system should construct a
+  Bundle Specifier from the provided package name and the active
+  locale. For example, when retrieving a message template for
+  French Canadian, in the <code>mathlib</code> package, the bundle
+  specifier '<code>(mathlib fr ca)</code>' is used. A program may
+  also retrieve the elements of the current locale using the
+  no-argument procedures:</p>
 
-    <blockquote>
-      When given no arguments, returns the current ISO 639-1
-      language code as a symbol. &nbsp;If provided with an
-      argument, the current language is set to that named by the
-      symbol for the currently executing Scheme thread (or for the
-      entire Scheme system if such a distinction is not possible).
-      &nbsp;
-    </blockquote>
+  <p><b><code id="current-language">current-language</code></b>
+  <code>-&gt; <i>symbol</i></code><br>
+  <code><b>current-language</b> <i>symbol</i> -&gt;
+  undefined</code><br></p>
 
-    <p><b><code id="current-country">current-country</code></b> <code>-&gt;
-    <i>symbol</i></code><br>
-     <code><b>current-country</b> <i>symbol</i> -&gt;
-    undefined</code><br>
-    </p>
+  <blockquote>
+    When given no arguments, returns the current ISO 639-1 language
+    code as a symbol. &nbsp;If provided with an argument, the
+    current language is set to that named by the symbol for the
+    currently executing Scheme thread (or for the entire Scheme
+    system if such a distinction is not possible). &nbsp;
+  </blockquote>
 
-    <blockquote>
-      returns the current ISO 3166-1 country code as a symbol.
-      &nbsp;If provided with an argument, the current country is
-      set to that named by the symbol for the currently executing
-      Scheme thread (or for the entire Scheme system if such a
-      distinction is not possible). &nbsp;&nbsp;
-    </blockquote>
+  <p><b><code id="current-country">current-country</code></b>
+  <code>-&gt; <i>symbol</i></code><br>
+  <code><b>current-country</b> <i>symbol</i> -&gt;
+  undefined</code><br></p>
 
-    <p><b><code id="current-locale-details">current-locale-details</code></b> <code>-&gt; <i>list of
-    symbol</i></code>s<br>
-     <code><b>current-locale-details</b> <i>list-of-symbols</i> -&gt;
-    undefined</code><br>
-    </p>
+  <blockquote>
+    returns the current ISO 3166-1 country code as a symbol.
+    &nbsp;If provided with an argument, the current country is set
+    to that named by the symbol for the currently executing Scheme
+    thread (or for the entire Scheme system if such a distinction
+    is not possible). &nbsp;&nbsp;
+  </blockquote>
 
-    <blockquote>
-      Returns a list of additional locale details as a list of
-      symbols. &nbsp;This list may contain information about
-      encodings or other more specific information. &nbsp;If
-      provided with an argument, the current locale details are set
-      to those given in the currently executing Scheme thread (or
-      for the entire Scheme system if such a distinction is not
-      possible).&nbsp;
-    </blockquote>
+  <p><b><code id=
+  "current-locale-details">current-locale-details</code></b>
+  <code>-&gt; <i>list of symbol</i></code>s<br>
+  <code><b>current-locale-details</b> <i>list-of-symbols</i> -&gt;
+  undefined</code><br></p>
 
-    <p>The Scheme System should first check for a bundle with the
-    exact name provided. If no such bundle is found, the last
-    element from the list is removed and a search is tried for a
-    bundle with that name. If no bundle is then found, the list is
-    shortened by removing the last element again. If no message is
-    found and the bundle specifier is now the empty list, an error
-    should be raised.</p>
+  <blockquote>
+    Returns a list of additional locale details as a list of
+    symbols. &nbsp;This list may contain information about
+    encodings or other more specific information. &nbsp;If provided
+    with an argument, the current locale details are set to those
+    given in the currently executing Scheme thread (or for the
+    entire Scheme system if such a distinction is not
+    possible).&nbsp;
+  </blockquote>
 
-    <p>The reason for this search order is to provide the most
-    locale sensitive template possible, but to fall back on more
-    general templates if a translation has not yet been provided
-    for the given locale.</p>
+  <p>The Scheme System should first check for a bundle with the
+  exact name provided. If no such bundle is found, the last element
+  from the list is removed and a search is tried for a bundle with
+  that name. If no bundle is then found, the list is shortened by
+  removing the last element again. If no message is found and the
+  bundle specifier is now the empty list, an error should be
+  raised.</p>
 
-    <h3>Message Templates</h3>
+  <p>The reason for this search order is to provide the most locale
+  sensitive template possible, but to fall back on more general
+  templates if a translation has not yet been provided for the
+  given locale.</p>
 
-    <p>A message template is a localized message that may or may
-    not contain one of a number of formatting codes. A message
-    template is a Scheme string. The string is of a form that can
-    be processed by the <code>format</code> procedure found in many
-    Scheme systems and formally specified in SRFI-28 (Basic Format
-    Strings).</p>
+  <h3>Message Templates</h3>
 
-    <p>This SRFI also extends SRFI-28 to provide an additional
-    <code>format</code> escape code:</p>
+  <p>A message template is a localized message that may or may not
+  contain one of a number of formatting codes. A message template
+  is a Scheme string. The string is of a form that can be processed
+  by the <code>format</code> procedure found in many Scheme systems
+  and formally specified in SRFI-28 (Basic Format Strings).</p>
 
-    <blockquote>
-      <code>~[n]@*</code> - Causes a value-requiring escape code that
-      follows this code immediately to reference the [N]'th
-      optional value absolutely, rather than the next unconsumed
-      value. The referenced value is <i>not</i> consumed.
-    </blockquote>
-    <p>This extension allows optional values to be positionally
-    referenced, so that message templates can be constructed that
-    can produce the proper word ordering for a language.</p>
+  <p>This SRFI also extends SRFI-28 to provide an additional
+  <code>format</code> escape code:</p>
 
-    <h3>Preparing Bundles</h3>
-    <p>Before a bundle may be used by the Scheme system to retrieve
-    localized template messages, they must be made available to the
-    Scheme system. &nbsp;This SRFI specifies a way to portably
-    define the bundles, as well as store them in and retrieve them
-    from an unspecified system which may be provided by resources
-    outside the Scheme system.</p>
+  <blockquote>
+    <code>~[n]@*</code> - Causes a value-requiring escape code that
+    follows this code immediately to reference the [N]'th optional
+    value absolutely, rather than the next unconsumed value. The
+    referenced value is <i>not</i> consumed.
+  </blockquote>
 
+  <p>This extension allows optional values to be positionally
+  referenced, so that message templates can be constructed that can
+  produce the proper word ordering for a language.</p>
 
-    <p><b><code id="declare-bundle!">declare-bundle!</code></b> <code><i>bundle-specifier
-    association-list</i> -&gt; undefined<br>
-    </code></p>
+  <h3>Preparing Bundles</h3>
 
-    <blockquote>
-      Declares a new bundle named by the given bundle-specifier.
-      &nbsp;The contents of the bundle are defined by the provided
-      association list. &nbsp;The list contains associations
-      between Scheme symbols and the message templates (Scheme
-      strings) they name. &nbsp;If a bundle already exists with the
-      given name, it is overwritten with the newly declared
-      bundle.<br>
-    </blockquote>
-    <code id="store-bundle"><b>store-bundle</b> <i>bundle-specifier</i> -&gt;
-    boolean</code><br>
+  <p>Before a bundle may be used by the Scheme system to retrieve
+  localized template messages, they must be made available to the
+  Scheme system. &nbsp;This SRFI specifies a way to portably define
+  the bundles, as well as store them in and retrieve them from an
+  unspecified system which may be provided by resources outside the
+  Scheme system.</p>
 
+  <p><b><code id="declare-bundle!">declare-bundle!</code></b>
+  <code><i>bundle-specifier association-list</i> -&gt;
+  undefined<br></code></p>
 
-    <blockquote>
-      Attempts to store a bundle named by the given bundle
-      specifier, and previously made available using
-      <code>declare-bundle!</code> or <code>load-bundle!</code>, in an
-      unspecified mechanism that may be persistent across Scheme
-      system restarts. &nbsp;If successful, a non-false value is
-      returned. &nbsp;If unsuccessful, <code>#f</code> is returned.<br>
-    </blockquote>
-    <code id="load-bundle!"><b>load-bundle!</b> <i>bundle-specifier</i> -&gt;
-    boolean</code><br>
+  <blockquote>
+    Declares a new bundle named by the given bundle-specifier.
+    &nbsp;The contents of the bundle are defined by the provided
+    association list. &nbsp;The list contains associations between
+    Scheme symbols and the message templates (Scheme strings) they
+    name. &nbsp;If a bundle already exists with the given name, it
+    is overwritten with the newly declared bundle.<br>
+  </blockquote>
+  <code id="store-bundle"><b>store-bundle</b>
+  <i>bundle-specifier</i> -&gt; boolean</code><br>
 
+  <blockquote>
+    Attempts to store a bundle named by the given bundle specifier,
+    and previously made available using
+    <code>declare-bundle!</code> or <code>load-bundle!</code>, in
+    an unspecified mechanism that may be persistent across Scheme
+    system restarts. &nbsp;If successful, a non-false value is
+    returned. &nbsp;If unsuccessful, <code>#f</code> is
+    returned.<br>
+  </blockquote>
+  <code id="load-bundle!"><b>load-bundle!</b>
+  <i>bundle-specifier</i> -&gt; boolean</code><br>
 
-    <blockquote>
-      Attempts to retrieve a bundle from an unspecified mechanism
-      which stores bundles outside the Scheme system. &nbsp;If the
-      bundle was retrieved successfully, the function returns a
-      non-false value, and the bundle is immediately available to
-      the Scheme system. If the bundle could not be found or loaded
-      successfully, the function returns <code>#f</code>, and the
-      Scheme system's bundle registry remains unaffected.<br>
-    </blockquote>
-    <p>A compliant Scheme system may choose not to provide any
-    external mechanism to store localized bundles. &nbsp;If it does
-    not, it must still provide implementations for
-    <code>store-bundle</code> and <code>load-bundle!</code>. In such a
-    case, both functions must return <code>#f</code> regardless of the
-    arguments given. Users of this SRFI should recognize that the
-    inability to load or store a localized bundle in an external
-    repository is <i>not</i> a fatal error.</p>
+  <blockquote>
+    Attempts to retrieve a bundle from an unspecified mechanism
+    which stores bundles outside the Scheme system. &nbsp;If the
+    bundle was retrieved successfully, the function returns a
+    non-false value, and the bundle is immediately available to the
+    Scheme system. If the bundle could not be found or loaded
+    successfully, the function returns <code>#f</code>, and the
+    Scheme system's bundle registry remains unaffected.<br>
+  </blockquote>
 
+  <p>A compliant Scheme system may choose not to provide any
+  external mechanism to store localized bundles. &nbsp;If it does
+  not, it must still provide implementations for
+  <code>store-bundle</code> and <code>load-bundle!</code>. In such
+  a case, both functions must return <code>#f</code> regardless of
+  the arguments given. Users of this SRFI should recognize that the
+  inability to load or store a localized bundle in an external
+  repository is <i>not</i> a fatal error.</p>
 
-    <h3>Retrieving Localized Message Templates</h3>
+  <h3>Retrieving Localized Message Templates</h3>
 
-    <p><b><code id="localized-template">localized-template</code></b> <i><code>package-name
-    message-template-name</code></i> <code>-&gt; <i>string or #f<br>
-    </i></code></p>
+  <p><b><code id="localized-template">localized-template</code></b>
+  <i><code>package-name message-template-name</code></i>
+  <code>-&gt; <i>string or #f<br></i></code></p>
 
-    <blockquote>
-      Retrieves a localized message template for the given package
-      name and the given message template name (both symbols).
-      &nbsp;If no such message could be found, false (#f) is
-      returned.<br>
-      <br>
-    </blockquote>
-    <p>After retrieving a template, the calling program can use
-    <code>format</code> to produce a string that can be displayed to
-    the user.</p>
+  <blockquote>
+    Retrieves a localized message template for the given package
+    name and the given message template name (both symbols).
+    &nbsp;If no such message could be found, false (#f) is
+    returned.<br>
+    <br>
+  </blockquote>
 
+  <p>After retrieving a template, the calling program can use
+  <code>format</code> to produce a string that can be displayed to
+  the user.</p>
 
-    <h3>Examples</h3>
-   <p>The below example makes use of SRFI-29 to display simple,
-    localized messages. &nbsp;It also defines its bundles in such a
-    way that the Scheme system may store and retrieve the bundles
-    from a more efficient system catalog, if available.</p>
+  <h3>Examples</h3>
 
-<pre>
+  <p>The below example makes use of SRFI-29 to display simple,
+  localized messages. &nbsp;It also defines its bundles in such a
+  way that the Scheme system may store and retrieve the bundles
+  from a more efficient system catalog, if available.</p>
+
+  <pre>
 (let ((translations
        '(((en) . ((time . "Its ~a, ~a.")
                 (goodbye . "Goodbye, ~a.")))
@@ -303,23 +315,22 @@
 ;; Fred, c'est 12:00.
 ;; Au revoir, Fred.
 </pre>
+  <h2 id="implementation">Implementation</h2>
 
-    <h2 id="implementation">Implementation</h2>
+  <p>The implementation requires that the Scheme system provide a
+  definition for <code>current-language</code> and
+  <code>current-country</code> capable of distinguishing the
+  correct locale present during a Scheme session. The definitions
+  of those functions in the reference implementation are not
+  capable of that distinction. Their implementation is provided
+  only so that the following code can run in any R4RS scheme
+  system. &nbsp;<br></p>
 
-    <p>The implementation requires that the Scheme system provide a
-    definition for <code>current-language</code> and
-    <code>current-country</code> capable of distinguishing the correct
-    locale present during a Scheme session. The definitions of
-    those functions in the reference implementation are not capable
-    of that distinction. Their implementation is provided only so
-    that the following code can run in any R4RS scheme system.
-    &nbsp;<br>
-    </p>
+  <p>In addition, the below implementation of a compliant
+  <code>format</code> requires SRFI-6 (Basic String Ports) and
+  SRFI-23 (Error reporting)</p>
 
-    <p>In addition, the below implementation of a compliant
-    <code>format</code> requires SRFI-6 (Basic String Ports) and
-    SRFI-23 (Error reporting)</p>
-<pre>
+  <pre>
 ;; The association list in which bundles will be stored
 (define *localization-bundles* '())
 
@@ -463,44 +474,43 @@
                     (loop (cdr format-list) objects #f)))))))
 
 </pre>
+  <h2 id="copyright">Copyright</h2>
 
-    <h2 id="copyright">Copyright</h2>
-    <p>&copy; 2002 Scott G. Miller.</p>
+  <p>© 2002 Scott G. Miller.</p>
 
-    <p>
-      Permission is hereby granted, free of charge, to any person
-      obtaining a copy of this software and associated documentation files
-      (the "Software"), to deal in the Software without restriction,
-      including without limitation the rights to use, copy, modify, merge,
-      publish, distribute, sublicense, and/or sell copies of the Software,
-      and to permit persons to whom the Software is furnished to do so,
-      subject to the following conditions:</p>
+  <p>Permission is hereby granted, free of charge, to any person
+  obtaining a copy of this software and associated documentation
+  files (the "Software"), to deal in the Software without
+  restriction, including without limitation the rights to use,
+  copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the
+  Software is furnished to do so, subject to the following
+  conditions:</p>
 
-    <p>
-      The above copyright notice and this permission notice (including the
-      next paragraph) shall be included in all copies or substantial
-      portions of the Software.</p>
-    <p>
-      THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-      NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
-      BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
-      ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-      CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-      SOFTWARE.</p>
+  <p>The above copyright notice and this permission notice
+  (including the next paragraph) shall be included in all copies or
+  substantial portions of the Software.</p>
 
-      <hr>
+  <p>THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY
+  KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+  AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+  HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+  OTHER DEALINGS IN THE SOFTWARE.</p>
 
-    <address>
-      Editor: <a href="mailto:srfi+minus+editors+at+srfi+dot+schemers+dot+org">David
-      Rush</a>
-    </address>
+  <hr>
 
-    <address>
-      Author: <a href="mailto:scgmille@freenetproject.org">Scott G.
-      Miller</a>
-    </address>
-  </body>
+  <address>
+    Editor: <a href=
+    "mailto:srfi+minus+editors+at+srfi+dot+schemers+dot+org">David
+    Rush</a>
+  </address>
+
+  <address>
+    Author: <a href="mailto:scgmille@freenetproject.org">Scott G.
+    Miller</a>
+  </address>
+</body>
 </html>
-


### PR DESCRIPTION
As I proposed in <https://github.com/racket/srfi/issues/4#issuecomment-967327336>, this pull request adds `id` attributes based on Racket's old copy of this document to enable linking directly to the specification of the identifiers defined by the SRFI.

I've left this in several commits and am marking it as a draft to ask a few further questions:

- At a minimum, I would plan to squash the `<H1>` commit, since I go on to replace most of them with properly-nested headings.
- The document did not have its SRFI number in the heading. I adjusted the title and author based on the current [`srfi-template.html`](https://github.com/scheme-requests-for-implementation/srfi-common/blob/16eb7e08e518c43894c4c60dc190be7d1c9edea7/srfi-template.html): does that seem right?
- I suspect running HTML Tidy is probably not worth the enormous diff.
- More broadly than this SRFI, I think `<img class="srfi-logo" src="https://srfi.schemers.org/srfi-logo.svg" alt="SRFI surfboard logo">` ought instead to use `alt="SRFI"`, perhaps with `aria-description="SRFI surfboard logo"`. The current markup is rendered by non-graphical user-agents as "SRFI surfboard logo 224: Integer Mappings".